### PR TITLE
improve metrics for postgresql connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Correctly evaluate and collect metrics for active connections and active connections waiting on backend locks
+- Add new metric `total`
 
 ## [0.1.0] - 2016-03-09
 ### Added

--- a/bin/metric-postgres-connections.rb
+++ b/bin/metric-postgres-connections.rb
@@ -84,7 +84,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
       result.each do |row|
         if row['waiting'] == 't'
           metrics[:waiting] = row['count']
-        elsif role['waiting'] == 'f'
+        elsif row['waiting'] == 'f'
           metrics[:active] = row['count']
         end
       end

--- a/bin/metric-postgres-connections.rb
+++ b/bin/metric-postgres-connections.rb
@@ -77,17 +77,20 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     metrics = {
       active: 0,
-      waiting: 0
+      waiting: 0,
+      total: 0
     }
     con.exec(request.join(' ')) do |result|
       result.each do |row|
-        if row['waiting']
+        if row['waiting'] == 't'
           metrics[:waiting] = row['count']
-        else
+        elsif role['waiting'] == 'f'
           metrics[:active] = row['count']
         end
       end
     end
+
+    metrics[:total] = (metrics[:waiting].to_i + metrics[:active].to_i)
 
     metrics.each do |metric, value|
       output "#{config[:scheme]}.connections.#{config[:db]}.#{metric}", value, timestamp


### PR DESCRIPTION
- determine more accurately which connections are "active"
- determine more accurately which connections are "waiting" on lock
- produce new metric called total

The result of the select statement can, and will, return a hash that may or may not have more than one result.

`select count(*), waiting from pg_stat_activity where datname = 'mydatabase' group by waiting;`

```
 count | waiting
-------+---------
   160 | f
     5 | t
```

The resulting in two items to evaluate  

```
{ "count" => "160", "waiting" => "f" }
{ "count" => "5", "waiting" => "t" }
```

[Currently](https://github.com/sensu-plugins/sensu-plugins-postgres/blob/8ed2e39b1c73dad91c3f215e73623da5066c0e1a/bin/metric-postgres-connections.rb#L83) the way the metric would be evaluated only one of those results would be considered the winner for the resulting "waiting" metric and the "active" metric will always be 0. 

[This](https://github.com/slyness/sensu-plugins-postgres/blob/connection_metrics/bin/metric-postgres-connections.rb#L84-L90) change makes sure that each type of count is collected into the bucket it is supposed to be in and it also adds a new metric, "[total](https://github.com/slyness/sensu-plugins-postgres/blob/connection_metrics/bin/metric-postgres-connections.rb#L93)", to accurately show the sum of all connections (locked or active) as one value.

Reference: http://www.postgresql.org/docs/9.4/static/monitoring-stats.html
