### PR TITLE
Fix connections metric to work with postgres 9.6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metric-postgres-connections: Handle postgres version 9.6 and above.
+
 ### Changed
 - Updated all the scripts to add an optional timeout setting.
 

--- a/bin/metric-postgres-connections.rb
+++ b/bin/metric-postgres-connections.rb
@@ -83,12 +83,12 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
     request = [
       "select case when count(*) = 1 then 'waiting' else",
       "'case when wait_event_type is null then false else true end' end as wait_col",
-      "from information_schema.columns",
+      'from information_schema.columns',
       "where table_name = 'pg_stat_activity' and table_schema = 'pg_catalog'",
       "and column_name = 'waiting'"
     ]
     wait_col = con.exec(request.join(' ')).first['wait_col']
-    
+
     request = [
       "select count(*), #{wait_col} as waiting from pg_stat_activity",
       "where datname = '#{config[:database]}' group by #{wait_col}"


### PR DESCRIPTION
## Pull Request Checklist

This is in reference to issue #21 

#### General

- [ x ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Fix the connection metric so that it will work properly under postgres 9.6 and above and still also work with previous versions of postgres.

#### Known Compatablity Issues

