### PR TITLE
Adds missing option for custom port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## [1.1.2] - 2017-06-02
+## 2017-06-02
 - check-postgresq-replication.rb: Adds missing option for custom port.
 
 ## [1.1.1] - 2017-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.1.2] - 2017-06-02
+- check-postgresq-replication.rb: Adds missing option for custom port.
+
 ## [1.1.1] - 2017-04-24
 ### Fixed
 - metrics-postgres-query.rb: Restored default value to only return first value in query. (@Micasou)

--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -17,7 +17,7 @@
 #   gem: pg
 #
 # USAGE:
-#   ./check-postgres-replication.rb -m master_host -s slave_host -d db -u db_user -p db_pass -w warn_threshold -c crit_threshold
+#   ./check-postgres-replication.rb -m master_host -s slave_host -P port -d db -u db_user -p db_pass -w warn_threshold -c crit_threshold
 #
 # NOTES:
 #
@@ -40,6 +40,12 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
          long: '--slave-host=HOST',
          description: 'PostgreSQL slave HOST',
          default: 'localhost')
+
+  option(:port,
+         short: '-P',
+         long: '--port=PORT',
+         description: 'PostgreSQL port',
+         default: 5432)
 
   option(:database,
          short: '-d',
@@ -111,6 +117,7 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
                             dbname: config[:database],
                             user: config[:user],
                             password: config[:password],
+                            port: config[:port],
                             sslmode: ssl_mode,
                             connect_timeout: config[:timeout])
 

--- a/lib/sensu-plugins-postgres/version.rb
+++ b/lib/sensu-plugins-postgres/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsPostgres
   module Version
     MAJOR = 1
     MINOR = 1
-    PATCH = 1
+    PATCH = 2
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#27 introduced custom ports but did not allow the port to be passed as a parameter.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

`check-postgres-replication.rb` should allow passing a custom port.

For example, a server may use pgbouncer which runs on port 6543.

#### Known Compatibility Issues

None at this time.