### PR TITLE
Add a nil check to avoid failure when the query result is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-postgres-query.rb: Add a nil check to avoid failure when the query result is empty (@eheydrick)
 
 ## [1.4.0] - 2017-08-04
 ### Added

--- a/bin/metrics-postgres-query.rb
+++ b/bin/metrics-postgres-query.rb
@@ -114,7 +114,7 @@ class MetricsPostgresQuery < Sensu::Plugin::Metric::CLI::Graphite
     value = if config[:count_tuples]
               res.ntuples
             else
-              res.first.values.first
+              res.first.values.first unless res.first.nil?
             end
 
     if config[:multirow] && !config[:count_tuples]


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Bug fix for case when a query returns no results. Fixes a regression introduced in 1.1.1.

Before:
```
./metrics-postgres-query.rb ... -s 'something' -q "QUERY THAT RETURNS NO RESULTS"
Check failed to run: undefined method `values' for nil:NilClass, ["/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-postgres-1.4.0/bin/metrics-postgres-query.rb:117:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.4.4/lib/s
```
After:
```
./metrics-postgres-query.rb ... -s 'something' -q "QUERY THAT RETURNS NO RESULTS"
```

Query that returns results:
```
./metrics-postgres-query.rb ... -s 'something' -q "QUERY THAT RETURNS RESULTS"
something 27.7237785714286 1506469791
```

#### Known Compatability Issues

None.
