### PR TITLE
Fix check-replication compatibility in 9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+### Fixed
+- check-postgres-replication.rb: fix 9.x compatibility
 
 ## [1.4.3] - 2017-11-06
 ### Fixed

--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -106,7 +106,7 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
 
   def check_vsn(conn)
     pg_vsn = conn.exec("SELECT current_setting('server_version')").getvalue(0, 0)
-    return if Gem::Version.new(pg_vsn) < Gem::Version.new('10.0') && Gem::Version.new(pg_vsn) >= Gem::Version.new('9.0')
+    Gem::Version.new(pg_vsn) < Gem::Version.new('10.0') && Gem::Version.new(pg_vsn) >= Gem::Version.new('9.0')
   end
 
   def run


### PR DESCRIPTION
## Pull Request Checklist

#40 

#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues

#### Artificats

Added a debug statement to output pg version in check_vsn (hence PG version in output)

***9.6.5***
```
check-postgres-replication.rb \
-m 10.2.3.16 \
-s 10.2.13.17 \
-P 6543 \
-d airbrake_sensu_96 \
-u sensu_replication_96 \
-p MWZRnwyZuwtq \
-w 900 \
-c 1800
9.6.5
9.6.5
CheckPostgresReplicationStatus OK: replication delayed by 0.0MB :: master:0/44000060 slave:0/44000060 m_segbytes:16777216
```

***10.0***
```
check-postgres-replication.rb \
  -m 10.2.3.180 \
  -s 10.2.13.160 \
  -P 6543 \
  -d airbrake_sensu_test \
  -u sensu_replication \
  -p MWZRnwyZuwtq \
  -w 900 \
  -c 1800
10.0
10.0
CheckPostgresReplicationStatus OK: replication delayed by 16.010719299316406MB :: master:4EE5/5F002BE8 slave:4EE5/5E000000 m_segbytes:16777216
```