### PR TITLE
skel for integration testing:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 .DS_Store
 .idea/*
 *.gem
+.kitchen/*

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,34 @@
+---
+driver:
+  name: docker
+  use_sudo: false
+  links:
+    # TODO: multiple versions at some point
+    - sensu-postgres-10:sensu-postgres-10
+
+provisioner:
+  name: shell
+  data_path: .
+  script: test/fixtures/bootstrap.sh
+
+# verifier:
+#   ruby_bindir: <%= ENV['MY_RUBY_HOME'] || '/opt/sensu/embedded' %>/bin
+verifier:
+  ruby_bindir: /usr/local/bin
+
+platforms:
+  - name: debian-8
+
+suites:
+  - name: ruby-21
+    driver:
+      image: ruby:2.1-slim
+  - name: ruby-22
+    driver:
+      image: ruby:2.2-slim
+  - name: ruby-230
+    driver:
+      image: ruby:2.3.0-slim
+  - name: ruby-241
+    driver:
+      image: ruby:2.4.1-slim

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: true
+service: docker
 language: ruby
 cache:
 - bundler
+before_install:
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+  - gem install bundler -v 1.15
 install:
 - bundle install
 rvm:
@@ -14,8 +19,12 @@ notifications:
     - sensu-plugin@sensu-plugins.io
     on_success: change
     on_failure: always
+before_script:
+  - docker run --name sensu-postgres-10 -e POSTGRES_PASSWORD='<REDACTED>' -d postgres
+
 script:
-- bundle exec rake default
+- bundle exec rake quick
+- bundle exec rake kitchen:ruby-`echo $TRAVIS_RUBY_VERSION | sed -e "s/\.//g"`-debian-8
 - gem build sensu-plugins-postgres.gemspec
 - gem install sensu-plugins-postgres-*.gem
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Added
+- basic skel for integration testing with postgres (@majormoses)
+- added test for `./bin/check-postgres-alive.rb`
+
 ## [1.4.4] - 2017-11-08
 ### Fixed
 - check-postgres-replication.rb: fix 9.x compatibility

--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,13 @@ require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
+require 'English'
+require 'kitchen/rake_tasks'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +37,10 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+Kitchen::RakeTasks.new
+
+desc 'Alias for kitchen:all'
+task integration: 'kitchen:all'
+
+task default: %i[spec make_bin_executable yard rubocop check_binstubs integration]
+task quick: %i[make_bin_executable yard rubocop check_binstubs]

--- a/lib/sensu-plugins-postgres/pgpass.rb
+++ b/lib/sensu-plugins-postgres/pgpass.rb
@@ -1,7 +1,7 @@
 module Pgpass
   def pgpass
     if File.file?(config[:pgpass])
-      pgpass = Hash[[:hostname, :port, :database, :user, :password].zip(File.readlines(config[:pgpass])[0].strip.split(':'))]
+      pgpass = Hash[%i[hostname port database user password].zip(File.readlines(config[:pgpass])[0].strip.split(':'))]
       pgpass[:database] = nil if pgpass[:database] == '*'
       pgpass.each do |k, v|
         config[k] ||= v

--- a/sensu-plugins-postgres.gemspec
+++ b/sensu-plugins-postgres.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-postgres'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
 
   s.date                   = Date.today.to_s
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
                               more.'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-postgres'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -35,16 +35,23 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsPostgres::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'pg',           '0.18.3'
+
   s.add_runtime_dependency 'dentaku',      '2.0.4'
+  s.add_runtime_dependency 'pg',           '0.18.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
+  s.add_development_dependency 'kitchen-docker',            '~> 2.6'
+  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
+  # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
+  s.add_development_dependency 'mixlib-shellout',           ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
+  s.add_development_dependency 'serverspec',                '~> 2.36.1'
+  s.add_development_dependency 'test-kitchen',              '~> 1.16.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Set up a super simple web server and make it accept GET and POST requests
+# for Sensu plugin testing.
+#
+
+set -e
+
+# base utilities that need to exist to start bootatraping
+apt-get update
+apt-get install -y wget
+
+# setup the rubies
+source /etc/profile
+DATA_DIR=/tmp/kitchen/data
+RUBY_HOME=${MY_RUBY_HOME}
+
+# Start bootatraping
+
+## install some required deps for pg_gem to install
+apt-get install -y libpq-dev build-essential
+
+# setup postgres server
+## TODO: multiple postgres versions and replication the versions should probably
+## be matrixed but wanted to start as small as possible initially.
+
+
+# End of Actual bootatrap
+
+# Install gems
+cd $DATA_DIR
+SIGN_GEM=false gem build sensu-plugins-postgres.gemspec
+gem install sensu-plugins-postgres-*.gem

--- a/test/integration/helpers/serverspec/check-postgres-alive-shared_spec.rb
+++ b/test/integration/helpers/serverspec/check-postgres-alive-shared_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'
+
+gem_path = '/usr/local/bin'
+check_name = 'check-postgres-alive.rb'
+check = "#{gem_path}/#{check_name}"
+pg_user = 'postgres'
+pg_password = '<REDACTED>'
+# TODO: fix up the hostname to be pulled in via the suite based on the version being tested
+pg_host = 'sensu-postgres-10'
+
+describe 'ruby environment' do
+  it_behaves_like 'ruby checks', check
+end
+
+# NOTE: This ia a TERRIBLE idea and you should never specify a cleartext
+# password on the cli like this. you should use the pgpass or sensu tokens:
+# https://sensuapp.org/docs/1.1/reference/checks.html#check-token-substitution
+# do not use this method for anything but testing.
+describe command("#{check} --user #{pg_user} --password \'#{pg_password}\' --hostname #{pg_host}") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/CheckPostgres OK: Server version: {"version"=>"PostgreSQL/) }
+end

--- a/test/integration/helpers/serverspec/shared_spec.rb
+++ b/test/integration/helpers/serverspec/shared_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for 'ruby checks' do |check|
+  describe command('which ruby') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/\/usr\/local\/bin\/ruby/) }
+  end
+
+  describe command('which gem') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/\/usr\/local\/bin\/gem/) }
+  end
+
+  describe command("which #{check}") do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(Regexp.new(Regexp.escape(check))) }
+  end
+
+  describe file(check) do
+    it { should be_file }
+    it { should be_executable }
+  end
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'serverspec'
+
+set :backend, :exec

--- a/test/integration/ruby-21/serverspec/default_spec.rb
+++ b/test/integration/ruby-21/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/integration/ruby-22/serverspec/default_spec.rb
+++ b/test/integration/ruby-22/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/integration/ruby-230/serverspec/default_spec.rb
+++ b/test/integration/ruby-230/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/integration/ruby-241/serverspec/default_spec.rb
+++ b/test/integration/ruby-241/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,9 @@
+# frozen_string_literal: true
+
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
+
+RSpec.configure do |c|
+  c.formatter = :documentation
+  c.color = true
+end


### PR DESCRIPTION
- Framework: `test-kitchen`, `kitchen-docker`, and `serverspec`
- Postgres 10 in docker container, currently handled by travis or externally bringing up a docker container with the same command. kitchen will create a link allowing it to connect with its name. At the moment its currently hard coded bad juju so this should be cleaned up later just wanted to get something out.
- Basic test for `check-postgres-alive`

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

relates to #40 


#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Adds the skel and a single functional test, right now it only does one postgres version, is kinda clunky, and needs love but I just want to get something out there.
#### Known Compatibility Issues
None.