### PR TITLE
fix version number check for build strings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+### Fixed
+- version number check for build strings such as `10.3 (Ubuntu 10.3-1.pgdg16.04+1)`
 
 ### Added
 - tests for connecting with a pgpass file (@majormoses)

--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -106,6 +106,7 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
 
   def check_vsn(conn)
     pg_vsn = conn.exec("SELECT current_setting('server_version')").getvalue(0, 0)
+    pg_vsn = pg_vsn.split(' ')[0]
     Gem::Version.new(pg_vsn) < Gem::Version.new('10.0') && Gem::Version.new(pg_vsn) >= Gem::Version.new('9.0')
   end
 


### PR DESCRIPTION
such as `10.3 (Ubuntu 10.3-1.pgdg16.04+1)`