### PR TITLE
Fix metric-postgres-graphite.rb replication function names for Postgres 10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+### Fixed
+- replication status function names for postgres v10 in `bin/metric-postgres-graphite.rb` (@jfineberg)
 
 ## [1.4.6] - 2018-05-03
 ### Fixed
-- version number check for build strings such as `10.3 (Ubuntu 10.3-1.pgdg16.04+1)`
+- version number check for build strings such as `10.3 (Ubuntu 10.3-1.pgdg16.04+1)` (@jfineberg)
 
 ### Added
 - tests for connecting with a pgpass file (@majormoses)

--- a/bin/metric-postgres-graphite.rb
+++ b/bin/metric-postgres-graphite.rb
@@ -104,7 +104,7 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
                              password: config[:password],
                              port: config[:port],
                              connect_timeout: config[:timeout])
-   master = if check_vsn(conn_master)
+    master = if check_vsn(conn_master)
               conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0, 0)
             else
               conn_master.exec('SELECT pg_current_wal_lsn()').getvalue(0, 0)

--- a/bin/metric-postgres-graphite.rb
+++ b/bin/metric-postgres-graphite.rb
@@ -105,10 +105,10 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
                              port: config[:port],
                              connect_timeout: config[:timeout])
     master = if check_vsn(conn_master)
-              conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0, 0)
-            else
-              conn_master.exec('SELECT pg_current_wal_lsn()').getvalue(0, 0)
-            end
+               conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0, 0)
+             else
+               conn_master.exec('SELECT pg_current_wal_lsn()').getvalue(0, 0)
+             end
     m_segbytes = conn_master.exec('SHOW wal_segment_size').getvalue(0, 0).sub(/\D+/, '').to_i << 20
     conn_master.close
 


### PR DESCRIPTION
- Refactor metric-postgres-graphite.rb to operate like check-postgres-replication.rb
-- performs a version check and uses the appropriate function names for getting replication status.
-- thanks to @phumpal in e5194d6d67337b21f757dba0478afb12401dd10d for the solution

Resolves #52 