### PR TITLE
Remove unexplicit dependency on ActiveSupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- Remove unexplicit dependency on ActiveSupport (@multani)
+
 ## [2.2.1] - 2018-10-16
 ### Security
 - updated yard dependency to `~> 0.9.11` per: https://nvd.nist.gov/vuln/detail/CVE-2017-17042 (@majormoses)

--- a/bin/metric-postgres-statsdb.rb
+++ b/bin/metric-postgres-statsdb.rb
@@ -29,7 +29,6 @@
 #   for details.
 #
 
-require 'active_support/core_ext/hash'
 require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
@@ -95,7 +94,8 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
     ]
     con.exec(request.join(' ')) do |result|
       result.each do |row|
-        row.except('datid', 'stats_reset').each do |key, value|
+        row.each do |key, value|
+          next if %w[datid stats_reset].include?(key)
           output "#{config[:scheme]}.statsdb.#{config[:database]}.#{key}", value.to_s, timestamp
         end
       end


### PR DESCRIPTION
The dependency wasn't declared in the plugin dependencies (I'm not sure how
it could have worked before?)

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### Purpose

This simplifies the plugin (remove non-explicit dependency) and makes the code slightly easier to read (no need to know what ActiveSupport `.except` is doing).

#### Known Compatibility Issues

None


#### Side note

I found this while trying to debug the plugin: on a new installation I have, reaching this `.except` code line makes the Ruby interpreter to segfault:

```
# ./bin/metric-postgres-statsdb.rb
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/pg-0.18.3/lib/pg.rb:45: [BUG] Segmentation fault at 0x0000000000000000
ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0006 p:---- s:0028 e:000027 CFUNC  :initialize
c:0005 p:---- s:0025 e:000024 CFUNC  :new
c:0004 p:0020 s:0020 e:000019 METHOD /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/pg-0.18.3/lib/pg.rb:45
c:0003 p:0092 s:0015 e:000014 METHOD ./bin/metric-postgres-statsdb.rb:86
c:0002 p:0039 s:0008 e:000007 BLOCK  /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58 [FINISH]
c:0001 p:0000 s:0003 E:000200 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'
./bin/metric-postgres-statsdb.rb:86:in `run'
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/pg-0.18.3/lib/pg.rb:45:in `connect'
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/pg-0.18.3/lib/pg.rb:45:in `new'
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/pg-0.18.3/lib/pg.rb:45:in `initialize'
```

I'm not sure how this specific line could do that, but between the Ruby interpreter ship with Sensu which is a bit old, the `pg` gem which is even older and the latest libpq version I had, it somehow helps :)