### PR TITLE
Fix metric-postgres-graphite.rb replication function names for PostgreSQL 10.x+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+### Fixed
+- Support for PostgreSQL v10+ replication function names fixed in `bin/metric-postgres-graphite.rb` (@jfineberg)
 
 ## [2.2.2] - 2018-10-27
 ### Fixed
@@ -28,7 +30,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [1.4.6] - 2018-05-03
 ### Fixed
-- version number check for build strings such as `10.3 (Ubuntu 10.3-1.pgdg16.04+1)`
+- version number check for build strings such as `10.3 (Ubuntu 10.3-1.pgdg16.04+1)` (@jfineberg)
 
 ### Added
 - tests for connecting with a pgpass file (@majormoses)

--- a/bin/metric-postgres-graphite.rb
+++ b/bin/metric-postgres-graphite.rb
@@ -89,6 +89,7 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
          default: nil
 
   include Pgpass
+  include PgUtil
 
   def run
     ssl_mode = config[:ssl] ? 'require' : 'prefer'


### PR DESCRIPTION
## Pull Request Checklist

This will address Issue #52 and provide graphite metrics support in PostgreSQL 10.x+

Refactor metric-postgres-graphite.rb to operate like check-postgres-replication.rb using common methods provided in lib.

-- performs a version check and uses the appropriate function names for getting replication status.