### PR TITLE
metric-postgres-statsdb.rb: Add --all-databases option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+### Added
+- metric-postgres-statsdb.rb: Add --all-databases option.
 
 ## [2.2.2] - 2018-10-27
 ### Fixed


### PR DESCRIPTION
This allow to get the stats for all databases instead of only the one we are connected on.

```
$ bundle exec bin/metric-postgres-statsdb.rb -h localhost --port 5432 -u test --scheme test
test.statsdb.postgres.numbackends 1 1543919094
test.statsdb.postgres.xact_commit 278841 1543919094
test.statsdb.postgres.xact_rollback 9026 1543919094
test.statsdb.postgres.blks_read 7241 1543919094
test.statsdb.postgres.blks_hit 12408835 1543919094
test.statsdb.postgres.tup_returned 104080136 1543919094
test.statsdb.postgres.tup_fetched 4092909 1543919094
test.statsdb.postgres.tup_inserted 29146 1543919094
test.statsdb.postgres.tup_updated 6345 1543919094
test.statsdb.postgres.tup_deleted 29130 1543919094
test.statsdb.postgres.conflicts 0 1543919094
test.statsdb.postgres.temp_files 0 1543919094
test.statsdb.postgres.temp_bytes 0 1543919094
test.statsdb.postgres.deadlocks 0 1543919094
test.statsdb.postgres.blk_read_time 0 1543919094
test.statsdb.postgres.blk_write_time 0 1543919094
```
```
$ bundle exec bin/metric-postgres-statsdb.rb -h localhost --port 5432 -u test --scheme test --all-databases
test.statsdb.postgres.numbackends 1 1543919144
test.statsdb.postgres.xact_commit 278843 1543919144
test.statsdb.postgres.xact_rollback 9026 1543919144
test.statsdb.postgres.blks_read 7241 1543919144
test.statsdb.postgres.blks_hit 12409011 1543919144
test.statsdb.postgres.tup_returned 104080216 1543919144
test.statsdb.postgres.tup_fetched 4092988 1543919144
test.statsdb.postgres.tup_inserted 29146 1543919144
test.statsdb.postgres.tup_updated 6345 1543919144
test.statsdb.postgres.tup_deleted 29130 1543919144
test.statsdb.postgres.conflicts 0 1543919144
test.statsdb.postgres.temp_files 0 1543919144
test.statsdb.postgres.temp_bytes 0 1543919144
test.statsdb.postgres.deadlocks 0 1543919144
test.statsdb.postgres.blk_read_time 0 1543919144
test.statsdb.postgres.blk_write_time 0 1543919144
test.statsdb.template1.numbackends 0 1543919144
test.statsdb.template1.xact_commit 0 1543919144
test.statsdb.template1.xact_rollback 0 1543919144
test.statsdb.template1.blks_read 0 1543919144
test.statsdb.template1.blks_hit 0 1543919144
test.statsdb.template1.tup_returned 0 1543919144
test.statsdb.template1.tup_fetched 0 1543919144
test.statsdb.template1.tup_inserted 0 1543919144
test.statsdb.template1.tup_updated 0 1543919144
test.statsdb.template1.tup_deleted 0 1543919144
test.statsdb.template1.conflicts 0 1543919144
test.statsdb.template1.temp_files 0 1543919144
test.statsdb.template1.temp_bytes 0 1543919144
test.statsdb.template1.deadlocks 0 1543919144
test.statsdb.template1.blk_read_time 0 1543919144
test.statsdb.template1.blk_write_time 0 1543919144
test.statsdb.template0.numbackends 0 1543919144
test.statsdb.template0.xact_commit 0 1543919144
test.statsdb.template0.xact_rollback 0 1543919144
test.statsdb.template0.blks_read 0 1543919144
test.statsdb.template0.blks_hit 0 1543919144
test.statsdb.template0.tup_returned 0 1543919144
test.statsdb.template0.tup_fetched 0 1543919144
test.statsdb.template0.tup_inserted 0 1543919144
test.statsdb.template0.tup_updated 0 1543919144
test.statsdb.template0.tup_deleted 0 1543919144
test.statsdb.template0.conflicts 0 1543919144
test.statsdb.template0.temp_files 0 1543919144
test.statsdb.template0.temp_bytes 0 1543919144
test.statsdb.template0.deadlocks 0 1543919144
test.statsdb.template0.blk_read_time 0 1543919144
test.statsdb.template0.blk_write_time 0 1543919144
test.statsdb.test_db.numbackends 0 1543919144
test.statsdb.test_db.xact_commit 23046 1543919144
test.statsdb.test_db.xact_rollback 0 1543919144
test.statsdb.test_db.blks_read 190 1543919144
test.statsdb.test_db.blks_hit 797090 1543919144
test.statsdb.test_db.tup_returned 12136286 1543919144
test.statsdb.test_db.tup_fetched 128047 1543919144
test.statsdb.test_db.tup_inserted 1 1543919144
test.statsdb.test_db.tup_updated 18 1543919144
test.statsdb.test_db.tup_deleted 0 1543919144
test.statsdb.test_db.conflicts 0 1543919144
test.statsdb.test_db.temp_files 0 1543919144
test.statsdb.test_db.temp_bytes 0 1543919144
test.statsdb.test_db.deadlocks 0 1543919144
test.statsdb.test_db.blk_read_time 0 1543919144
test.statsdb.test_db.blk_write_time 0 1543919144
test.statsdb.test2.numbackends 0 1543919144
test.statsdb.test2.xact_commit 0 1543919144
test.statsdb.test2.xact_rollback 0 1543919144
test.statsdb.test2.blks_read 0 1543919144
test.statsdb.test2.blks_hit 0 1543919144
test.statsdb.test2.tup_returned 0 1543919144
test.statsdb.test2.tup_fetched 0 1543919144
test.statsdb.test2.tup_inserted 0 1543919144
test.statsdb.test2.tup_updated 0 1543919144
test.statsdb.test2.tup_deleted 0 1543919144
test.statsdb.test2.conflicts 0 1543919144
test.statsdb.test2.temp_files 0 1543919144
test.statsdb.test2.temp_bytes 0 1543919144
test.statsdb.test2.deadlocks 0 1543919144
test.statsdb.test2.blk_read_time 0 1543919144
test.statsdb.test2.blk_write_time 0 1543919144

```