### PR TITLE
metric-postgres-statsdb: maintain backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+- metric-postgres-statsdb.rb: Change append to push to maintain compatibility w/ non-EOL Rubies
 
 ## [2.3.0] - 2018-12-08
 ### Added

--- a/bin/metric-postgres-statsdb.rb
+++ b/bin/metric-postgres-statsdb.rb
@@ -101,7 +101,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
     params = []
     unless config[:all_databases]
       query += ' WHERE datname = $1'
-      params.append config[:database]
+      params.push config[:database]
     end
 
     con.exec_params(query, params) do |result|


### PR DESCRIPTION
The `append` alias is only available if ActiveRecord is loaded _or_
sensu is running ruby-2.5.1.

This change maintains backwards compatibility with non-EOL Rubies.

**Before**
```
Check failed to run: undefined method `append' for []:Array,
["/opt/sensu/.rvm/gems/ruby-2.4.1/gems/sensu-plugins-postgres-2.3.0/bin/metric-postgres-statsdb.rb:104:in
`run'",
"/opt/sensu/.rvm/gems/ruby-2.4.1/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in
`block in <class:CLI>'"]
```

**After**
```
CheckPostgres OK: Server version: {"version"=>"PostgreSQL 11.1 (Ubuntu
11.1-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu
7.3.0-27ubuntu1~18.04) 7.3.0, 64-bit"}
```

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
