### PR TITLE
use sensu-plugins 4.0, add enable for Bonsai listing

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -1,0 +1,27 @@
+---
+description: "#{repo}"
+builds:
+- platform: "debian"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_debian_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+  -  "entity.system.platform == 'debian'"
+- platform: "centos"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_centos_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+  -  "entity.system.platform == 'rhel'"
+- platform: "alpine"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_alpine_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+  -  "entity.system.platform == 'alpine'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+### Added
+- .bonsai.yml descriptor for listing on https://bonsai.sensu.io
+
+### Changed
+- updated sensu-plugin dependency to 4.0
 
 ## [2.3.2] - 2019-03-12
 ### Fixed

--- a/sensu-plugins-postgres.gemspec
+++ b/sensu-plugins-postgres.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsPostgres::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 4.0'
 
   s.add_runtime_dependency 'dentaku',      '2.0.4'
   s.add_runtime_dependency 'pg',           '0.18.3'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x ] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [none ] Update README with any necessary configuration snippets

- [none] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Have the postgres plugins available via the bonsai asset library for easy distribution

#### Known Compatibility Issues
For Bonsai/asset deployment: will this plugin always depend on system libraries (pg)?