### PR TITLE
timeout should not be a boolean and should always be cast as an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+
+### Fixed
+- check-postgres-replication.rb: fix condition where connection timeout is considered a boolean rather than an integer value (@majormoses) (@phumpal) (@VeselaHouba)
+
 ### Added
 - `check-postgres-query.rb`: Add `-r`, `--regex-pattern` to match query result against (@jindraj)
 
 ### Changes
 - Updated development dependency to bundler ~> 2.1
-- Updated development dependency to rake ~> 13.0 
-- Updated development dependency to test-kitchen ~> 1.25.0 
-- Updated runtime dependency to 'pg' '1.2.1' from 1.1   
+- Updated development dependency to rake ~> 13.0
+- Updated development dependency to test-kitchen ~> 1.25.0
+- Updated runtime dependency to 'pg' '1.2.1' from 1.1
 - Updated runtime dependency 'dentaku' '3.3.4' from 2.04
 
 ### Breaking Changes

--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -94,10 +94,11 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
          proc: lambda { |s| s.to_i }) # rubocop:disable Lambda
 
   option(:timeout,
-         short: '-T',
-         long: '--timeout',
-         default: nil,
-         description: 'Connection timeout (seconds)')
+         short: '-T TIMEOUT',
+         long: '--timeout=TIMEOUT',
+         default: 2,
+         description: 'Connection timeout (seconds)',
+         proc: proc(&:to_i))
 
   include Pgpass
   include PgUtil


### PR DESCRIPTION
## Pull Request Checklist

fixes #109 

#### General

- [ ] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Fix a reported issue where the connection timeout was being treated as a boolean rather than an integer.

#### Known Compatibility Issues
None